### PR TITLE
 Fix Dynamic Database Configuration Caching Issue in Tenant Creation Process

### DIFF
--- a/src/Filament/Resources/TenantResource/Pages/CreateTenant.php
+++ b/src/Filament/Resources/TenantResource/Pages/CreateTenant.php
@@ -66,6 +66,7 @@ class CreateTenant extends CreateRecord
         $record = $this->record;
 
         config(['database.connections.dynamic.database' => config('tenancy.database.prefix').$record->id. config('tenancy.database.suffix')]);
+        DB::purge('dynamic');
         $user = DB::connection('dynamic')
             ->table('users')
             ->where('email', $record->email)


### PR DESCRIPTION
This pull request addresses an issue where the dynamic database connection in the tenant creation process was not updating properly due to Laravel's configuration caching. To ensure that the `dynamic` database connection reflects the correct tenant-specific database, the line `DB::purge('dynamic');` has been added after setting the configuration for the dynamic connection.

By purging the connection, we clear any previous database configuration and force Laravel to re-establish the connection with the updated settings. This ensures that database operations (such as inserting or updating tenant-specific users) correctly target the intended tenant database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tenant creation process to streamline user record management.
	- Automatic update or insertion of user records based on tenant creation.

- **Bug Fixes**
	- Improved database connection handling for dynamic configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->