### PR TITLE
Fix Dynamic Database Configuration Caching Issue in Tenant Creation Process

### DIFF
--- a/src/Filament/Resources/TenantResource/Pages/CreateTenant.php
+++ b/src/Filament/Resources/TenantResource/Pages/CreateTenant.php
@@ -65,8 +65,16 @@ class CreateTenant extends CreateRecord
 
         $record = $this->record;
 
-        config(['database.connections.dynamic.database' => config('tenancy.database.prefix').$record->id. config('tenancy.database.suffix')]);
-        DB::purge('dynamic');
+        try {
+            $dbName = config('tenancy.database.prefix') . $record->id . config('tenancy.database.suffix');
+            config(['database.connections.dynamic.database' => $dbName]);
+            DB::purge('dynamic');
+
+            DB::connection('dynamic')->getPdo();
+        } catch (\Exception $e) {
+            throw new \Exception("Failed to connect to tenant database: {$dbName}");
+        }
+
         $user = DB::connection('dynamic')
             ->table('users')
             ->where('email', $record->email)

--- a/src/Filament/Resources/TenantResource/Pages/CreateTenant.php
+++ b/src/Filament/Resources/TenantResource/Pages/CreateTenant.php
@@ -66,6 +66,7 @@ class CreateTenant extends CreateRecord
         $record = $this->record;
 
         config(['database.connections.dynamic.database' => config('tenancy.database.prefix').$record->id. config('tenancy.database.suffix')]);
+        DB::purge('dynamic');
         $user = DB::connection('dynamic')
             ->table('users')
             ->where('email', $record->email)

--- a/src/Filament/Resources/TenantResource/Pages/EditTenant.php
+++ b/src/Filament/Resources/TenantResource/Pages/EditTenant.php
@@ -39,6 +39,7 @@ class EditTenant extends EditRecord
         }
 
         config(['database.connections.dynamic.database' => config('tenancy.database.prefix').$record->id. config('tenancy.database.suffix')]);
+        DB::purge('dynamic');
         $user = DB::connection('dynamic')
             ->table('users')
             ->where('email', $record->email)


### PR DESCRIPTION
This pull request addresses an issue where the dynamic database connection in the tenant creation/update process was not updating properly due to Laravel's configuration caching. To ensure that the `dynamic` database connection reflects the correct tenant-specific database, the line `DB::purge('dynamic');` has been added after setting the configuration for the dynamic connection.

By purging the connection, we clear any previous database configuration and force Laravel to re-establish the connection with the updated settings. This ensures that database operations (such as inserting or updating tenant-specific users) correctly target the intended tenant database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tenant and user record management for improved data consistency in a multi-tenant environment.
	- Support for dynamic database connections, ensuring the latest settings are applied during operations.

- **Bug Fixes**
	- Improved error handling and control flow related to tenant and user data updates.

- **Refactor**
	- Separated domain record creation from tenant record management for clearer processes.
	- Updated error handling logic for database connections in tenant creation and editing processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->