### PR TITLE
Allow non-URL-safe characters in email addresses

### DIFF
--- a/src/Filament/Resources/TenantResource.php
+++ b/src/Filament/Resources/TenantResource.php
@@ -140,7 +140,7 @@ class TenantResource extends Resource
                     ->action(function ($record){
                         $token = tenancy()->impersonate($record, 1, '/app', 'web');
 
-                        return redirect()->to(request()->getScheme()."://".$record->domains[0]->domain.'.'. config('filament-tenancy.central_domain') . '/login/url?token='.$token->token .'&email='. $record->email);
+                        return redirect()->to(request()->getScheme()."://".$record->domains[0]->domain.'.'. config('filament-tenancy.central_domain') . '/login/url?token='.$token->token .'&email='. urlencode($record->email));
                     }),
                 Tables\Actions\Action::make('password')
                     ->label(trans('filament-tenancy::messages.actions.password'))


### PR DESCRIPTION
Fix redirection error when impersonating a tenant with an email containing non-URL-safe characters, such as the `+` sign used in emails like  `user+01@domain.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the login functionality by ensuring email addresses are properly encoded in the redirect URL, preventing potential issues with special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->